### PR TITLE
feat: add multilingual translation app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_GEMINI_API_KEY=your_gemini_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.DS_Store
+dist
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# TakumiTest
+# Multilingual Translation App
+
+A real-time multilingual translation web application using Google Gemini API, React, and Tailwind CSS.
+
+## Features
+- Translate text into up to five languages simultaneously
+- Auto detect source language
+- Save translation history and favorite languages
+- Dark/Light mode
+- Copy, speak aloud, and export translations
+- 5000 character limit with live counter and keyboard shortcut (Ctrl/Cmd + Enter)
+
+## Setup
+
+1. Clone the repository and install dependencies:
+
+```bash
+npm install
+```
+
+2. Create a `.env` file based on `.env.example` and provide your Google Gemini API key.
+
+3. Run the development server:
+
+```bash
+npm run dev
+```
+
+4. Build for production:
+
+```bash
+npm run build
+```
+
+## Testing
+
+This template does not include unit tests. You can run the placeholder test command:
+
+```bash
+npm test
+```
+
+## Environment Variables
+
+- `VITE_GEMINI_API_KEY`: API key for Google Gemini.
+
+## License
+
+MIT

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Multilingual Translator</title>
+  </head>
+  <body class="bg-white dark:bg-gray-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "multilingual-translation-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,83 @@
+import React, { useState, useEffect, useRef } from 'react';
+import Header from './components/Header';
+import Footer from './components/Footer';
+import TranslationInput from './components/TranslationInput';
+import LanguageSelector from './components/LanguageSelector';
+import TranslationResults from './components/TranslationResults';
+import ErrorBoundary from './components/ErrorBoundary';
+import useTranslation from './hooks/useTranslation';
+import useLocalStorage from './hooks/useLocalStorage';
+import { debounce } from './utils/helpers';
+
+/**
+ * Root application component.
+ */
+export default function App() {
+  const [text, setText] = useState('');
+  const [sourceLang, setSourceLang] = useState('auto');
+  const [targetLangs, setTargetLangs] = useState(['en']);
+  const [darkMode, setDarkMode] = useLocalStorage('darkMode', false);
+  const [history, setHistory] = useLocalStorage('history', []);
+
+  const { translations, loading, error, translate } = useTranslation();
+
+  const translateAndSave = async () => {
+    await translate(text, sourceLang, targetLangs);
+    if (text.trim()) {
+      setHistory([
+        ...history,
+        {
+          text,
+          sourceLang,
+          targetLangs,
+          translations,
+          time: Date.now(),
+        },
+      ]);
+    }
+  };
+
+  const debounced = useRef(debounce(translateAndSave, 500)).current;
+
+  useEffect(() => {
+    if (text.trim()) {
+      debounced();
+    }
+  }, [text, sourceLang, targetLangs]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', darkMode);
+  }, [darkMode]);
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header darkMode={darkMode} onToggle={() => setDarkMode(!darkMode)} />
+      <ErrorBoundary>
+        <main className="flex flex-1 flex-col md:flex-row">
+          <div className="md:w-1/2 p-4 space-y-4">
+            <LanguageSelector
+              sourceLang={sourceLang}
+              setSourceLang={setSourceLang}
+              targetLangs={targetLangs}
+              setTargetLangs={setTargetLangs}
+            />
+            <TranslationInput
+              text={text}
+              setText={setText}
+              onTranslate={translateAndSave}
+            />
+          </div>
+          <div className="md:w-1/2 p-4">
+            <TranslationResults
+              translations={translations}
+              loading={loading}
+              error={error}
+              history={history}
+            />
+          </div>
+        </main>
+      </ErrorBoundary>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+/**
+ * Error boundary to catch rendering errors.
+ */
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('ErrorBoundary caught an error', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div className="p-4 text-red-500">Something went wrong.</div>;
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+/**
+ * Application footer.
+ */
+export default function Footer() {
+  return (
+    <footer className="p-4 text-center text-sm text-gray-500 dark:text-gray-400">
+      <p>Powered by Google Gemini API</p>
+    </footer>
+  );
+}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+/**
+ * Application header with dark mode toggle.
+ * @param {{darkMode: boolean, onToggle: () => void}} props
+ */
+export default function Header({ darkMode, onToggle }) {
+  return (
+    <header className="flex items-center justify-between p-4 bg-primary text-white">
+      <h1 className="text-lg font-bold">Translator</h1>
+      <button
+        className="bg-secondary px-3 py-1 rounded"
+        onClick={onToggle}
+      >
+        {darkMode ? 'Light' : 'Dark'} Mode
+      </button>
+    </header>
+  );
+}

--- a/src/components/LanguageSelector.jsx
+++ b/src/components/LanguageSelector.jsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { languages } from '../utils/languages';
+import useLocalStorage from '../hooks/useLocalStorage';
+
+/**
+ * Select source and target languages.
+ * @param {Object} props
+ * @param {string} props.sourceLang
+ * @param {Function} props.setSourceLang
+ * @param {string[]} props.targetLangs
+ * @param {Function} props.setTargetLangs
+ */
+export default function LanguageSelector({
+  sourceLang,
+  setSourceLang,
+  targetLangs,
+  setTargetLangs,
+}) {
+  const [favorites, setFavorites] = useLocalStorage('favoriteLangs', []);
+
+  const toggleFavorite = (code) => {
+    setFavorites(
+      favorites.includes(code)
+        ? favorites.filter((c) => c !== code)
+        : [...favorites, code]
+    );
+  };
+
+  const handleTargetChange = (code) => {
+    if (targetLangs.includes(code)) {
+      setTargetLangs(targetLangs.filter((c) => c !== code));
+    } else if (targetLangs.length < 5) {
+      setTargetLangs([...targetLangs, code]);
+    }
+  };
+
+  const sortedLanguages = [...languages.filter(l => l.code !== 'auto')].sort((a, b) => {
+    const af = favorites.includes(a.code);
+    const bf = favorites.includes(b.code);
+    if (af === bf) return a.name.localeCompare(b.name);
+    return af ? -1 : 1;
+  });
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium">Source Language</label>
+        <select
+          value={sourceLang}
+          onChange={(e) => setSourceLang(e.target.value)}
+          className="mt-1 p-2 border rounded w-full dark:bg-gray-800"
+        >
+          {languages.map((lang) => (
+            <option key={lang.code} value={lang.code}>
+              {lang.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium">Target Languages (max 5)</label>
+        <div className="max-h-48 overflow-y-auto border p-2 rounded dark:bg-gray-800">
+          {sortedLanguages.map((lang) => (
+            <div key={lang.code} className="flex items-center justify-between py-1">
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={targetLangs.includes(lang.code)}
+                  onChange={() => handleTargetChange(lang.code)}
+                  className="mr-2"
+                />
+                {lang.name}
+              </label>
+              <button
+                type="button"
+                onClick={() => toggleFavorite(lang.code)}
+                className="text-yellow-400"
+                aria-label="favorite"
+              >
+                {favorites.includes(lang.code) ? '★' : '☆'}
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TranslationInput.jsx
+++ b/src/components/TranslationInput.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+/**
+ * Text area for input with counters and actions.
+ * @param {Object} props
+ * @param {string} props.text
+ * @param {Function} props.setText
+ * @param {Function} props.onTranslate
+ */
+export default function TranslationInput({ text, setText, onTranslate }) {
+  const max = 5000;
+  const handleChange = (e) => {
+    if (e.target.value.length <= max) {
+      setText(e.target.value);
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+      onTranslate();
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <textarea
+        value={text}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        className="w-full h-40 p-2 border rounded resize-none dark:bg-gray-800"
+        placeholder="Enter text to translate..."
+      />
+      <div className="flex justify-between items-center text-sm">
+        <span>{text.length}/{max}</span>
+        <div className="space-x-2">
+          <button
+            className="px-2 py-1 border rounded"
+            onClick={() => setText('')}
+          >
+            Clear
+          </button>
+          <button
+            className="px-2 py-1 bg-primary text-white rounded"
+            onClick={onTranslate}
+          >
+            Translate
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TranslationResults.jsx
+++ b/src/components/TranslationResults.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { copyToClipboard, downloadJSON, downloadCSV } from '../utils/helpers';
+import useLocalStorage from '../hooks/useLocalStorage';
+
+/**
+ * Display translation results.
+ * @param {Object} props
+ * @param {Array<{language:string,text:string,score:number}>} props.translations
+ * @param {boolean} props.loading
+ * @param {string|null} props.error
+ * @param {Array} props.history
+ */
+export default function TranslationResults({ translations, loading, error, history = [] }) {
+  const [favorites, setFavorites] = useLocalStorage('favoritePhrases', []);
+  const speak = (text, lang) => {
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = lang;
+    window.speechSynthesis.speak(utterance);
+  };
+
+  const exportJSON = () => downloadJSON('translations.json', translations);
+  const exportCSV = () => downloadCSV('translations.csv', translations);
+
+  const toggleFavorite = (text) => {
+    setFavorites(
+      favorites.includes(text)
+        ? favorites.filter((t) => t !== text)
+        : [...favorites, text]
+    );
+  };
+
+  return (
+    <div>
+      {loading && <div className="my-4">Translating...</div>}
+      {error && <div className="my-4 text-red-500">{error}</div>}
+      <div className="space-y-4">
+        {translations.map((t) => (
+          <div key={t.language} className="p-3 border rounded bg-gray-100 dark:bg-gray-800">
+            <div className="flex justify-between mb-2">
+              <h3 className="font-semibold">{t.language}</h3>
+              <span className="text-sm">Score: {t.score}</span>
+            </div>
+            <p className="whitespace-pre-wrap">{t.text}</p>
+            <div className="flex gap-2 mt-2 text-sm">
+              <button
+                className="px-2 py-1 border rounded"
+                onClick={() => copyToClipboard(t.text)}
+              >
+                Copy
+              </button>
+              <button
+                className="px-2 py-1 border rounded"
+                onClick={() => speak(t.text, t.language)}
+              >
+                Speak
+              </button>
+              <button
+                className="px-2 py-1 border rounded"
+                onClick={() => toggleFavorite(t.text)}
+              >
+                {favorites.includes(t.text) ? '★' : '☆'}
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+      {translations.length > 0 && (
+        <div className="flex gap-2 mt-4">
+          <button className="px-2 py-1 border rounded" onClick={exportJSON}>
+            Export JSON
+          </button>
+          <button className="px-2 py-1 border rounded" onClick={exportCSV}>
+            Export CSV
+          </button>
+        </div>
+      )}
+      {history.length > 0 && (
+        <div className="mt-6">
+          <h4 className="font-semibold mb-2">History</h4>
+          <ul className="text-sm space-y-1 max-h-40 overflow-y-auto">
+            {history.slice().reverse().map((h, i) => (
+              <li key={i} className="border-b pb-1">{h.text}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {favorites.length > 0 && (
+        <div className="mt-6">
+          <h4 className="font-semibold mb-2">Favorite Phrases</h4>
+          <ul className="text-sm space-y-1 max-h-40 overflow-y-auto">
+            {favorites.map((f, i) => (
+              <li key={i} className="border-b pb-1">{f}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Persist state to localStorage.
+ * @param {string} key
+ * @param {any} initialValue
+ */
+export default function useLocalStorage(key, initialValue) {
+  const [value, setValue] = useState(() => {
+    try {
+      const stored = localStorage.getItem(key);
+      return stored ? JSON.parse(stored) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // ignore
+    }
+  }, [key, value]);
+
+  return [value, setValue];
+}

--- a/src/hooks/useTranslation.js
+++ b/src/hooks/useTranslation.js
@@ -1,0 +1,46 @@
+import { useState, useRef } from 'react';
+import { translateText } from '../services/geminiApi';
+
+/**
+ * Hook to translate text using Gemini API with caching.
+ * @returns {Object}
+ */
+export default function useTranslation() {
+  const [translations, setTranslations] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const cache = useRef({});
+
+  /**
+   * Translate text into multiple languages.
+   * @param {string} text
+   * @param {string} sourceLang
+   * @param {string[]} targetLangs
+   */
+  const translate = async (text, sourceLang, targetLangs) => {
+    if (!text || !targetLangs.length) return;
+    const key = `${text}|${sourceLang}|${targetLangs.join(',')}`;
+    if (cache.current[key]) {
+      setTranslations(cache.current[key]);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const results = await Promise.all(
+        targetLangs.map(async (lang) => {
+          const res = await translateText(text, sourceLang, lang);
+          return { language: lang, text: res.translation, score: res.score };
+        })
+      );
+      setTranslations(results);
+      cache.current[key] = results;
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { translations, loading, error, translate };
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles/globals.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/services/geminiApi.js
+++ b/src/services/geminiApi.js
@@ -1,0 +1,30 @@
+const ENDPOINT = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent';
+
+/**
+ * Translate text using Google Gemini API.
+ * @param {string} text
+ * @param {string} sourceLang
+ * @param {string} targetLang
+ * @returns {Promise<{translation: string, score: number}>}
+ */
+export async function translateText(text, sourceLang, targetLang) {
+  const apiKey = import.meta.env.VITE_GEMINI_API_KEY;
+  const prompt = `Translate the following text from ${sourceLang} to ${targetLang}.\nProvide only the translation without any explanations.\nMaintain the original formatting and tone.\n\nText: ${text}`;
+
+  const res = await fetch(`${ENDPOINT}?key=${apiKey}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: [{ role: 'user', parts: [{ text: prompt }] }],
+    }),
+  });
+
+  if (!res.ok) {
+    const err = await res.json();
+    throw new Error(err.error?.message || 'Translation failed');
+  }
+  const data = await res.json();
+  const translation = data.candidates?.[0]?.content?.parts?.[0]?.text?.trim() || '';
+  const score = data.candidates?.[0]?.safetyRatings?.[0]?.probability || 1;
+  return { translation, score };
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-white text-gray-900 dark:bg-gray-900 dark:text-white;
+}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,0 +1,54 @@
+/**
+ * Debounce a function by the specified delay.
+ * @param {Function} fn - Function to debounce.
+ * @param {number} delay - Delay in milliseconds.
+ * @returns {Function} Debounced function.
+ */
+export function debounce(fn, delay) {
+  let timer;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), delay);
+  };
+}
+
+/**
+ * Copy text to clipboard.
+ * @param {string} text - Text to copy.
+ */
+export function copyToClipboard(text) {
+  navigator.clipboard?.writeText(text);
+}
+
+/**
+ * Download an object as a JSON file.
+ * @param {string} filename
+ * @param {any} data
+ */
+export function downloadJSON(filename, data) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Download an array of objects as CSV.
+ * @param {string} filename
+ * @param {Array<Object>} rows
+ */
+export function downloadCSV(filename, rows) {
+  if (!rows.length) return;
+  const headers = Object.keys(rows[0]);
+  const csv = [headers.join(','), ...rows.map(r => headers.map(h => JSON.stringify(r[h] ?? '')).join(','))].join('\n');
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/utils/languages.js
+++ b/src/utils/languages.js
@@ -1,0 +1,15 @@
+export const languages = [
+  { code: 'auto', name: 'Auto Detect' },
+  { code: 'ja', name: 'Japanese' },
+  { code: 'en', name: 'English' },
+  { code: 'zh-CN', name: 'Chinese (Simplified)' },
+  { code: 'zh-TW', name: 'Chinese (Traditional)' },
+  { code: 'ko', name: 'Korean' },
+  { code: 'es', name: 'Spanish' },
+  { code: 'fr', name: 'French' },
+  { code: 'de', name: 'German' },
+  { code: 'pt', name: 'Portuguese' },
+  { code: 'ru', name: 'Russian' },
+  { code: 'ar', name: 'Arabic' },
+  { code: 'hi', name: 'Hindi' },
+];

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,13 @@
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        primary: '#4F46E5',
+        secondary: '#10B981',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- build React + Tailwind multilingual translator using Google Gemini API
- support multi-language selection, history, favorites, dark mode, and export utilities
- document input limit and keyboard shortcut in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b143451a8083318dc24d539fb26e39